### PR TITLE
Issue 12 card refresh

### DIFF
--- a/app.py
+++ b/app.py
@@ -403,12 +403,23 @@ def _download_image(
 
 
 def generate_cat_card_text(report: dict, psychology: dict, preferred_style: str):
-    """呼叫 Gemini 產生貓卡敘述。"""  # 🟡 0929修改：貓卡文案
+    """呼叫 Gemini 產生貓卡敘述與生活推薦。"""  # 🟡 1007 修改『圖卡生成推薦』：擴充文案欄位
     prompt = (
-        "你是一位數位貓咪圖卡設計師，會根據使用者的健康與心理測驗資料提供一隻陪伴貓咪。\n"
-        "回傳 JSON，欄位包含 styleKey (bright/steady/healer 其一)、persona、name、speech (15 字內)、"
-        "summary (60 字內)、insight (50 字內)、action (40 字內)、keywords (陣列，可空)。"
-        "所有文字使用繁體中文。\n"
+        "你是一位數位貓咪圖卡策展師，會依據使用者的健康與心理測驗資料提供陪伴資訊。\n"
+        "請回傳 JSON，必須包含下列欄位：\n"
+        "- styleKey: bright/steady/healer 之一。\n"
+        "- persona: 角色定位。\n"
+        "- name: 貓咪名稱。\n"
+        "- speech: 15 字內、溫暖有記憶點的開場話。\n"
+        "- summary: 60 字內，以故事化語氣描述當前狀態，不可提到任何精確數值或檢驗指標。\n"
+        "- insight: 50 字內，給出情緒洞察，避免出現具體數字或醫療指標名稱。\n"
+        "- action: 40 字內，提出實際可行的小提醒，同樣勿出現具體檢驗數值。\n"
+        "- keywords: 陣列，可空。\n"
+        "- recommendations: 物件，內含 movie/music/activity 三個子欄位，每個子欄位需提供 title 與 reason。\n"
+        "  * movie: 推薦一部符合當前情緒需求的電影或影集，reason 需點出氛圍或療癒重點。\n"
+        "  * music: 推薦一首歌曲或播放清單，說明為何適合此刻的節奏。\n"
+        "  * activity: 推薦一個放鬆或充電的小活動，要具體且富有品味。\n"
+        "所有文字務必使用繁體中文，保持溫柔且有品味，不可引用精確的血壓、血脂等數值。\n"
         f"建議風格：{preferred_style}\n"
         f"健康資料：{json.dumps(report, ensure_ascii=False, default=str)}\n"
         f"心理測驗：{json.dumps(psychology, ensure_ascii=False, default=str)}"
@@ -449,36 +460,100 @@ CAT_STYLES = {
         "title": "陽光守護者",
         "names": ["小橘光", "暖暖", "Sunny 喵"],
         "speech": ["今天也要補充水分喵！", "保持笑容，活力滿分！"],
-        "description": "我感受到你{mood}的能量，讓我們一起維持 {health} 分的好狀態。",
+        "description": "我感受到你{mood}的能量，讓我們把這份耀眼溫度延續下去。",
         "actions": [
             "午休時間散步 10 分鐘，讓身體熱起來",
             "今天晚餐試試多彩蔬菜盤，補充維生素",
         ],
         "palette": ("#FFEAA7", "#FD79A8", "#FFAFCC", "#2d3436"),
+        "curations": {
+            "movie": ("《翻滾吧！阿信》", "熱血卻富含體貼的勵志故事，帶來向上的動力"),
+            "music": ("City Pop 暖陽歌單", "輕快律動喚醒身體的節奏感"),
+            "activity": ("戶外晨間伸展", "在陽光下活動筋骨，吸收自然能量"),
+        },     # 🟡 1007 修改『圖卡生成推薦』
     },
     "steady": {
         "title": "溫柔照護隊長",
         "names": ["小霧", "Cotton", "霜霜"],
         "speech": ["放慢腳步，我陪著你喵。", "今天也記得深呼吸三次。"],
-        "description": "你的關鍵字是 {mood}，我會在日常提醒你保持節奏，讓 {health} 分更穩定。",
+        "description": "你的關鍵字是 {mood}，我會在日常提醒你保持節奏，讓步調更穩定。",
         "actions": [
             "睡前做 5 分鐘伸展，放鬆肌肉",
             "把今天的情緒寫在手帳，整理一下心緒",
         ],
         "palette": ("#E0FBFC", "#98C1D9", "#3D5A80", "#2d3436"),
+        "curations": {
+            "movie": ("《小森林》", "四季料理與田園步調，撫慰敏感心緒"),
+            "music": ("Lo-fi 書寫清單", "柔和節拍陪你整理思緒"),
+            "activity": ("手寫一封慢信", "用文字梳理情緒，讓心安定下來"),
+        },
     },
     "healer": {
         "title": "療癒訓練師",
         "names": ["小湯圓", "Mochi", "露露"],
         "speech": ["我們慢慢來，沒關係的喵。", "先照顧好自己，我在旁邊。"],
-        "description": "看見你需要休息的訊號，我會當你的提醒小鬧鐘，陪你把 {health} 分調整回來。",
+        "description": "看見你需要休息的訊號，我會當你的提醒小鬧鐘，陪你一起慢慢修復。",
         "actions": [
             "安排 15 分鐘的呼吸練習，舒緩壓力",
             "今天對自己說聲辛苦了，給自己一個擁抱",
         ],
         "palette": ("#E8EAF6", "#C5CAE9", "#9FA8DA", "#2d3436"),
+        "curations": {
+            "movie": ("《海邊的曼徹斯特》", "細膩描寫失落後的修復，讓情緒被看見"),
+            "music": ("Neo Classical 冥想曲", "舒緩鋼琴聲穩定呼吸節奏"),
+            "activity": ("居家香氛冥想", "點上喜歡的味道，跟著引導冥想放鬆"),
+        },
     },
 }
+
+# 🟡 1007 修改『圖卡生成推薦』：預設影音與活動建議
+def _fallback_recommendations(style_key: str) -> list[dict[str, str]]:
+    style = CAT_STYLES.get(style_key, {})
+    curations = style.get("curations", {})
+    defaults = {
+        "movie": ("《向左走向右走》", "浪漫淺嘗的節奏，陪你梳理心情"),
+        "music": ("Bossa Nova 咖啡廳", "溫柔節拍讓心慢慢沉靜"),
+        "activity": ("傍晚散步", "換個場景，讓腦袋短暫放空"),
+    }
+    mapping = [
+        ("movie", "推薦電影"),
+        ("music", "推薦音樂"),
+        ("activity", "推薦活動"),
+    ]
+    recommendations = []
+    for key, label in mapping:
+        title, reason = curations.get(key, defaults[key])
+        recommendations.append({"label": label, "title": title, "reason": reason})
+    return recommendations
+
+# 🟡 1007 修改『圖卡生成推薦』：整合 AI 與預設推薦
+def _normalize_recommendations(ai_payload: dict | None, style_key: str) -> list[dict[str, str]]:
+    payload = ai_payload or {}
+    raw_recs = payload.get("recommendations") or {}
+    mapping = [
+        ("movie", "推薦電影"),
+        ("music", "推薦音樂"),
+        ("activity", "推薦活動"),
+    ]
+    fallback_list = _fallback_recommendations(style_key)
+    normalized = []
+    for key, label in mapping:
+        source = raw_recs.get(key) if isinstance(raw_recs, dict) else None
+        title = ""
+        reason = ""
+        if isinstance(source, dict):
+            title = str(source.get("title") or "").strip()
+            reason = str(source.get("reason") or "").strip()
+        if not title or not reason:
+            fallback = next((item for item in fallback_list if item["label"] == label), None)
+            if fallback:
+                title = title or fallback["title"]
+                reason = reason or fallback["reason"]
+        normalized.append({"label": label, "title": title, "reason": reason})
+    if len(normalized) > 2:
+        random.shuffle(normalized)
+        normalized = normalized[:2]  # 🟡 1007 修改圖卡：僅呈現兩則建議
+    return normalized
 
 
 def build_cat_card(report: dict, psychology: dict):
@@ -511,6 +586,7 @@ def build_cat_card(report: dict, psychology: dict):
 
     # Finalize fields with AI payload or defaults
     # 🟡 0929修改：先試圖抓對應圖檔，失敗再退回 TheCatAPI
+    # 🟡 1007 修改『圖卡生成推薦』
     name = (ai_payload or {}).get("name") or random.choice(style["names"])
     persona_key = _resolve_persona_key(health_value, mood_value)
     persona_label = CAT_PERSONA_METADATA.get(persona_key)
@@ -522,10 +598,13 @@ def build_cat_card(report: dict, psychology: dict):
         model_keywords = [k.strip() for k in model_keywords.split(",") if k.strip()]
     mood_label = "、".join(model_keywords[:3]) if model_keywords else "平衡"
 
-    description = (ai_payload or {}).get("summary") or style["description"].format(
-        mood=mood_label,
-        health=int(round(health_value)),
-    )
+    description_template = style.get("description", "{mood} 的氣息值得被珍惜。")
+    try:
+        description = (ai_payload or {}).get("summary") or description_template.format(
+            mood=mood_label
+        )
+    except Exception:
+        description = (ai_payload or {}).get("summary") or description_template
     insight = (
         (ai_payload or {}).get("insight")
         or psychology.get("summary")
@@ -550,7 +629,8 @@ def build_cat_card(report: dict, psychology: dict):
             {"label": "活力指數", "value": f"{vitality}%"},
             {"label": "陪伴力", "value": f"{companionship}%"},
             {"label": "穩定度", "value": f"{stability}%"},
-        ],
+        ],  # 前端不再顯示分數，但保留結構以利後續調整
+        "recommendations": _normalize_recommendations(ai_payload, style_key),  # 🟡 1007 修改『圖卡生成推薦』：加入影音與活動建議
         "style_key": style_key,
         "palette": style.get("palette"),
         "keywords_list": model_keywords,

--- a/templates/generate_card.html
+++ b/templates/generate_card.html
@@ -154,15 +154,19 @@
         
         /* 貓咪卡片設計 */
         .cat-card {
-            background: linear-gradient(135deg, #F6E4D3, #E2D1C3, #D5B79A); /* #1005庭婕這裡改成暖黃色漸層卡片 */
+            background: linear-gradient(135deg, #F6E4D3, #E2D1C3, #D5B79A); /* default fallback */
             border-radius: 24px;
             padding: clamp(24px, 5vw, 32px);
             margin: 0 auto 40px;
-            max-width: min(400px, 100%);
+            max-width: min(562px, 100%); /* 🟡 1007 修改8：再放大卡片寬度約 120% */
+            aspect-ratio: 9 / 14.4; /* 🟡 1007 修改8：高度減少為 90% */
             position: relative;
             box-shadow: 0 20px 40px rgba(0, 0, 0, 0.15);
             transform: perspective(1000px) rotateY(0deg);
             transition: transform 0.3s ease;
+            display: flex;
+            flex-direction: column;
+            gap: clamp(12px, 3vw, 20px);
         }
         
         .cat-card:hover {
@@ -197,8 +201,8 @@
         }
         
         .cat-image {
-            width: clamp(160px, 40vw, 200px);
-            height: clamp(160px, 40vw, 200px);
+            width: clamp(200px, 50vw, 250px); /* 🟡 1007 修改5：放大貓咪肖像 */
+            height: clamp(200px, 50vw, 250px);
             border-radius: 50%;
             object-fit: cover;
             border: 6px solid rgba(255, 255, 255, 0.8);
@@ -206,7 +210,7 @@
             margin: 0 auto;
             display: block;
         }
-        
+
         .cat-speech-bubble {
             position: absolute;
             top: -10px;
@@ -217,6 +221,9 @@
             font-size: 14px;
             color: #3F2B1E;
             box-shadow: 0 4px 12px rgba(63, 43, 30, 0.15);
+            white-space: nowrap; /* 🟡 1007 修改5：限定單行顯示 */
+            overflow: hidden;
+            text-overflow: ellipsis;
         }
         
         .cat-speech-bubble::after {
@@ -232,47 +239,63 @@
         }
         
         .cat-name {
-            font-size: 24px;
+            font-size: 28px; /* 🟡 1007 修改7：放大主要標題字體 */
             font-weight: 700;
             color: #2d3436;
             margin-bottom: 8px;
         }
         
         .cat-description {
-            font-size: 14px;
+            font-size: 17px; /* 🟡 1007 修改7：放大內文 */
             color: #636e72;
             line-height: 1.5;
             margin-bottom: 20px;
+            text-align: justify; /* 🟡 1007 修改圖卡：更平衡的排版 */
+            text-justify: inter-ideograph;
+            hyphens: auto;
         }
         
-        .health-status {
+        /* 🟡 1007 修改『圖卡生成推薦』：推薦清單樣式 */
+        .curation-list {
+            margin-top: 20px;
+            background: rgba(226, 209, 195, 0.45); /* 🟡 1007 修改5：統一推薦底色層 */
+            border-radius: 16px;
+            padding: 18px 16px;
+            display: grid;
+            gap: 14px;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); /* 🟡 1007 修改圖卡：左右排版 */
+        }
+
+        .curation-item {
             display: flex;
-            justify-content: space-between;
-            gap: 12px;
-            margin-bottom: 20px;
-            flex-wrap: wrap;
-        }
-        
-        .status-item {
-            flex: 1;
-            background: rgba(226, 209, 195, 0.7); /* #1005庭婕這裡讓健康指標區塊變暖黃色 */
-            padding: 12px 8px;
+            flex-direction: column;
+            gap: 6px;
             border-radius: 12px;
-            text-align: center;
+            padding: 12px;
+            border: 1px solid rgba(71, 109, 255, 0.28); /* 🟡 1007 修改5：以單一色系框線區隔 */
+            background: rgba(255, 255, 255, 0.72);
         }
-        
-        .status-label {
-            font-size: 10px;
-            color: #636e72;
-            margin-bottom: 4px;
-            text-transform: uppercase;
-            letter-spacing: 0.5px;
+
+        .curation-label {
+            font-size: 11px;
+            font-weight: 600;
+            letter-spacing: 0.1em;
+            color: #6b4d7a;
         }
-        
-        .status-value {
-            font-size: 16px;
+
+        .curation-title {
+            font-size: 19px; /* 🟡 1007 修改7：放大推薦標題 */
             font-weight: 700;
             color: #2d3436;
+        }
+
+        .curation-reason {
+            font-size: 15px; /* 🟡 1007 修改7：放大推薦說明 */
+            color: #4a4a4a;
+            line-height: 1.6;
+            text-align: justify;
+            text-justify: inter-ideograph;
+            hyphens: auto;
         }
         
         .ai-signature {
@@ -523,6 +546,11 @@
     {% set default_image = 'https://images.unsplash.com/photo-1526336024174-e58f5cdd8e13?crop=entropy&cs=tinysrgb&fit=max&fm=jpg' %}
     {% set card_url = c.get('cat_image_source') or card_image_url or c.get('image_url') or default_image %} <!-- 🟡 0929修改：優先使用資料庫圖卡來源 -->
     {% set proxy_card_url = card_url and url_for('proxy_image') ~ '?url=' ~ (card_url | urlencode) %}
+    {% set palette = c.get('palette') or ['#F6E4D3', '#E2D1C3', '#D5B79A', '#3F2B1E'] %}
+    {% set gradient = 'linear-gradient(135deg, ' ~ palette[0] ~ ', ' ~ palette[1] ~ ', ' ~ palette[2] ~ ')' %}
+    {% set speech_raw = c.speech or '你的健康是我的關注！' %}
+    {% set speech_clean = speech_raw.replace('嗨！', '').replace('哈囉！', '').replace('嗨!', '').replace('哈囉!', '').replace('嗨', '').replace('哈囉', '').replace('我是', '').strip() %} {# 🟡 1007 修改6：移除寒暄 #}
+    {% set speech_display = speech_clean if speech_clean else speech_raw %}
     <div class="container">
         <header class="header">
             <div class="logo">
@@ -546,14 +574,16 @@
             </p>
             
             <!-- 貓咪卡片 -->
-            <div class="cat-card" id="cat-card">
+            <div class="cat-card" id="cat-card" style="background: {{ gradient }};">
                 <div class="cat-card-header">
                     <div class="brand-logo">MEOW Yourself</div>
                     <div class="cat-type-badge">{{ c.persona or c.persona_label or '療癒系貓咪' }}</div> <!-- 0929修改：依照 AI 或九宮格顯示貓咪稱號 -->
                 </div>
                 
                 <div class="cat-image-section">
-                    <div class="cat-speech-bubble">{{ c.speech or '你的健康是我的關注！' }}</div>
+                    <div class="cat-speech-bubble"><!-- 🟡 1007 修改6：改為完整心情小語 -->
+                        {{ speech_display }}
+                    </div>
                     <img src="{{ card_url }}" alt="Your Cat" class="cat-image" {% if proxy_card_url %}data-proxy-src="{{ proxy_card_url }}"{% endif %} data-original-src="{{ card_url }}" />
                 </div>
                 
@@ -568,29 +598,17 @@
                     {% endif %}
                 </div>
                 
-                <div class="health-status">
-                    {% if c.stats %}
-                        {% for stat in c.stats %}
-                            <div class="status-item">
-                                <div class="status-label">{{ stat.label }}</div>
-                                <div class="status-value">{{ stat.value }}</div>
-                            </div>
-                        {% endfor %}
-                    {% else %}
-                        <div class="status-item">
-                            <div class="status-label">活力指數</div>
-                            <div class="status-value">85%</div>
-                        </div>
-                        <div class="status-item">
-                            <div class="status-label">關懷度</div>
-                            <div class="status-value">90%</div>
-                        </div>
-                        <div class="status-item">
-                            <div class="status-label">陪伴力</div>
-                            <div class="status-value">95%</div>
-                        </div>
-                    {% endif %}
+                {% if c.recommendations %}
+                <div class="curation-list"><!-- 🟡 1007 修改『圖卡生成推薦』：呈現影音與活動建議 -->
+                    {% for rec in c.recommendations %}
+                    <div class="curation-item"><!-- 🟡 1007 修改5：統一推薦底色 -->
+                        <div class="curation-label">{{ rec.label }}</div>
+                        <div class="curation-title">{{ rec.title }}</div>
+                        <div class="curation-reason">{{ rec.reason }}</div>
+                    </div>
+                    {% endfor %}
                 </div>
+                {% endif %}
                 
                 <div class="ai-signature">🤖 AI 生成專屬健康伙伴</div>
             </div>
@@ -653,8 +671,6 @@
             {% if psychology %}
             <div class="info-card">
                 <h3>情緒測驗摘要</h3>
-                {% set combined = psychology.get('combined_score') if psychology.get('combined_score') is not none else psychology.get('combinedScore') %}
-                <p><span class="info-label">綜合分數：</span>{{ combined if combined is not none else '尚未評估' }}</p>
                 {% if psychology.get('summary') %}
                 <p><span class="info-label">摘要：</span>{{ psychology.get('summary') }}</p>
                 {% endif %}

--- a/templates/psychology_test.html
+++ b/templates/psychology_test.html
@@ -359,36 +359,55 @@
                 <!-- GALING 10/4 貓咪 Logo 區塊 (使用 SVG 繪製 - 增加眼睛和鬍鬚) 
                  顏色已改為橘色 text-orange-400 -->
             <div class="mb-4">
-                <svg class="w-20 h-20 text-orange-400 mx-auto transform hover:scale-110 transition duration-300" viewBox="0 0 32 32" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
-                    <!-- 臉部主體 (Head) -->
-                    <circle cx="16" cy="18" r="10" fill="currentColor" fill-opacity="0.8" stroke="none"/>
-                    
-                    <!-- 左耳 (Left Ear) - 逆時針旋轉 45 度 (回到上一個旋轉版本)，Y 座標維持 11.7 -->
-                    <path d="M8 5.4 L12.5 11.7 L3.5 11.7 Z" fill="currentColor" transform="rotate(-50 8 12)"/>
-                    <!-- 右耳 (Right Ear) - 順時針旋轉 45 度 (回到上一個旋轉版本)，Y 座標維持 11.7 -->
-                    <path d="M24 5.4 L28.5 11.7 L19.5 11.7 Z" fill="currentColor" transform="rotate(50 24 12)"/>
-                    
-                    <!-- 眼睛 (Eyes - 深色圓點) -->
-                    <circle cx="12" cy="16" r="1.5" fill="#333" stroke="none"/>
-                    <circle cx="20" cy="16" r="1.5" fill="#333" stroke="none"/>
-                    
-                    <!-- 鼻子 (Nose - 小三角形) -->
-                    <path d="M16 18 L15 20 L17 20 Z" fill="#333" stroke="none"/>
-                    
-                    <!-- 鬍鬚 (Whiskers - 簡單線條) -->
-                    <line x1="20" y1="21" x2="28" y2="21" stroke="currentColor" stroke-opacity="0.6" stroke-width="1"/>
-                    <line x1="20" y1="23" x2="28" y2="24" stroke="currentColor" stroke-opacity="0.6" stroke-width="1"/>
-                    <line x1="12" y1="21" x2="4" y2="21" stroke="currentColor" stroke-opacity="0.6" stroke-width="1"/>
-                    <line x1="12" y1="23" x2="4" y2="24" stroke="currentColor" stroke-opacity="0.6" stroke-width="1"/>
+                <!-- 🟡 1007 修改10『貓咪談心室SVG』：更新為帶條紋與鬍鬚的貓咪圖示 -->
+                <svg class="w-24 h-24 mx-auto transform hover:scale-110 transition duration-300" viewBox="0 0 140 140" xmlns="http://www.w3.org/2000/svg">
+                    <defs>
+                        <radialGradient id="kittyFace" cx="50%" cy="45%" r="65%">
+                            <stop offset="0%" stop-color="#ffec9c" />
+                            <stop offset="100%" stop-color="#ffbf4f" />
+                        </radialGradient>
+                    </defs>
+                    <g stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M28 52 L46 20 L62 48" fill="#ffbf4f" stroke="#2b1b16" stroke-width="5" />
+                        <path d="M112 52 L94 20 L78 48" fill="#ffbf4f" stroke="#2b1b16" stroke-width="5" />
+                        <path d="M30 58 Q24 96 53 112 Q70 122 87 112 Q116 96 110 58 Q106 34 70 34 Q34 34 30 58" fill="url(#kittyFace)" stroke="#2b1b16" stroke-width="5" />
+                        <path d="M54 32 Q70 20 86 32" fill="none" stroke="#2b1b16" stroke-width="6" stroke-linecap="round" />
+                    </g>
+                    <g fill="#ffa861" stroke="#2b1b16" stroke-width="4">
+                        <path d="M55 38 C50 44 46 52 44 60 L52 58" />
+                        <path d="M85 38 C90 44 94 52 96 60 L88 58" />
+                    </g>
+                    <g fill="#2b1b16">
+                        <ellipse cx="55" cy="70" rx="7" ry="9" />
+                        <ellipse cx="85" cy="70" rx="7" ry="9" />
+                    </g>
+                    <path d="M66 74 L70 80 L74 74" fill="#2b1b16" />
+                    <path d="M58 86 C66 92 74 92 82 86" stroke="#2b1b16" stroke-width="5" stroke-linecap="round" fill="none" />
+                    <g stroke="#2b1b16" stroke-width="4" stroke-linecap="round">
+                        <path d="M40 70 L24 64" />
+                        <path d="M41 78 L23 78" />
+                        <path d="M40 86 L24 92" />
+                        <path d="M100 70 L116 64" />
+                        <path d="M99 78 L117 78" />
+                        <path d="M100 86 L116 92" />
+                    </g>
+                    <g fill="#fff">
+                        <circle cx="52" cy="66" r="2.5" />
+                        <circle cx="82" cy="66" r="2.5" />
+                    </g>
+                    <g fill="none" stroke="#ff8d54" stroke-width="6" stroke-linecap="round">
+                        <path d="M58 46 L66 46" />
+                        <path d="M70 42 L70 52" />
+                        <path d="M82 46 L90 46" />
+                    </g>
+                    <g fill="#ff9aa2">
+                        <circle cx="46" cy="84" r="4" />
+                        <circle cx="94" cy="84" r="4" />
+                    </g>
                 </svg>
             </div>
                  <h1 class="text-4xl md:text-5xl font-bold mb-2">貓咪談心室</h1>
                 <p class="text-lg text-[var(--text-secondary)]">選一位貓咪朋友，開始你們的悄悄話時間。</p>
-                <!-- 🟢 修改開始：提供重新上傳健檢報告入口（強化外觀與新增貓爪 emoji） -->
-                <a href="{{ url_for('upload_health', reupload=1) }}" class="inline-flex items-center gap-4 mt-6 px-8 py-3.5 rounded-full text-base font-semibold text-gray-700 border border-transparent bg-white/90 shadow-lg hover:shadow-xl hover:-translate-y-0.5 transition-all" style="font-size: 200%;">
-                    <span class="flex items-center gap-3">🐾 我要重新上傳報告</span>
-                </a>
-                <!-- 🟢 修改結束 -->
             </div>
             <div class="grid grid-cols-1 md:grid-cols-2 gap-8 w-full max-w-3xl">
                 <button onclick="selectMode('deep-chat')" class="group bg-[var(--bg-secondary)] p-8 rounded-2xl custom-shadow-lg hover:shadow-2xl hover:-translate-y-1.5 transition-all text-left flex items-center gap-6 relative overflow-hidden selection-mode-card" data-bubble-color="rgba(184, 172, 215, 0.55)">
@@ -407,6 +426,12 @@
                         <p class="text-[var(--text-secondary)] text-sm mt-2 leading-relaxed">由專業的「喵記者馬克」提問 3 題至 15 題選擇題，你可以三選一作答，也可以改輸入文字傳送答案；若感覺聊夠了可以按「悄悄話總結」，讓馬克陪你快速釐清當下的心情與狀況。</p>
                     </div>
                 </button>
+            </div>
+            <!-- 🟡 1007 修改『重新上傳報告』：調整位置與字體 -->
+            <div class="mt-8 text-center">
+                <a href="{{ url_for('upload_health', reupload=1) }}" class="inline-flex items-center gap-3 px-6 py-2.5 rounded-full text-base font-semibold text-gray-700 border border-transparent bg-white/90 shadow-lg hover:shadow-xl hover:-translate-y-0.5 transition-all" style="font-size: 90%;">
+                    <span class="flex items-center gap-2">🐾 我要重新上傳報告</span>
+                </a>
             </div>
         </div>
 
@@ -916,7 +941,12 @@
             }
             const summaryReminder = document.getElementById('summary-reminder');
             if (summaryReminder) {
-                summaryReminder.classList.remove('hidden-section'); // 🟡 1007 修改圖卡：總結出現時顯示提醒
+                const reminderMessages = {
+                    'deep-chat': '奶奶會聽你慢慢說，這裡讓你可以想說什麼就說什麼。當你聊夠了，可以點「悄悄話總結」結束對話並生成圖卡',
+                    'quick-qa': '當你聊夠了，可以點「悄悄話總結」結束對話並生成圖卡',
+                };
+                summaryReminder.textContent = reminderMessages[appState.mode] || reminderMessages['quick-qa']; // 🟡 1007 修改貓咪談心室：依模式調整提醒文字
+                summaryReminder.classList.remove('hidden-section');
             }
         }
         
@@ -950,7 +980,7 @@
             }
             const summaryReminder = document.getElementById('summary-reminder');
             if (summaryReminder) {
-                summaryReminder.classList.add('hidden-section'); // 🟡 1007 修改圖卡：重置時隱藏提醒
+                summaryReminder.classList.add('hidden-section'); // 🟡 1007 修改貓咪談心室：重置時隱藏提醒
             }
             if (magicOverlay) {
                 magicOverlay.classList.remove('active'); // 🟡 1006 修改：重設時隱藏魔法動畫

--- a/templates/psychology_test.html
+++ b/templates/psychology_test.html
@@ -432,8 +432,8 @@
                     <div id="quick-replies-container" class="p-2 flex flex-wrap gap-2 justify-center border-t border-gray-100">
                         <!-- Quick replies will be injected here -->
                     </div>
-                    <!-- 🟡 1005 修改：提示使用者可透過悄悄話總結結束對話並生成圖卡 -->
-                    <p class="px-4 text-center text-[var(--text-secondary)] text-xs tracking-wide">當你聊夠了，可以點「悄悄話總結」結束對話並生成圖卡</p>
+                    <!-- 🟡 1007 修改圖卡：待總結可見提醒 -->
+                    <p id="summary-reminder" class="px-4 text-center text-[var(--text-secondary)] text-xs tracking-wide hidden-section">當你聊夠了，可以點「悄悄話總結」結束對話並生成圖卡</p>
                     <div class="p-4 border-t border-gray-100">
                         <!-- GALING 10/02 對話框尺寸調大 -->
                         <div class="flex items-center gap-3 chat-input-wrapper w-full">
@@ -895,7 +895,7 @@
             if (!document.getElementById('generate-card-button')) {
                 const buttonContainer = document.createElement('div');
                 buttonContainer.className = 'mt-6 text-center';
-                
+
                 const generateCardBtn = document.createElement('button');
                 generateCardBtn.id = 'generate-card-button';
                 generateCardBtn.className = 'bg-gradient-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600 text-white font-bold py-3 px-8 rounded-full shadow-lg hover:shadow-xl transition-all duration-300 transform hover:scale-105';
@@ -910,9 +910,13 @@
                         window.location.href = "{{ url_for('generate_card') }}";
                     }, 220);
                 });
-                
+
                 buttonContainer.appendChild(generateCardBtn);
                 summaryContainer.appendChild(buttonContainer);
+            }
+            const summaryReminder = document.getElementById('summary-reminder');
+            if (summaryReminder) {
+                summaryReminder.classList.remove('hidden-section'); // 🟡 1007 修改圖卡：總結出現時顯示提醒
             }
         }
         
@@ -943,6 +947,10 @@
             const existingButton = document.getElementById('generate-card-button');
             if (existingButton) {
                 existingButton.parentElement.remove();
+            }
+            const summaryReminder = document.getElementById('summary-reminder');
+            if (summaryReminder) {
+                summaryReminder.classList.add('hidden-section'); // 🟡 1007 修改圖卡：重置時隱藏提醒
             }
             if (magicOverlay) {
                 magicOverlay.classList.remove('active'); // 🟡 1006 修改：重設時隱藏魔法動畫
@@ -1299,7 +1307,7 @@
 
             return `
                 你的角色: 你是一位專業的心理分析師，同時也是一位溫暖的貓咪夥伴。
-                你的任務: 根據以下的健康報告摘要與對話紀錄，產生一份結構化的分析報告，並將身心狀態串連在一起給出建議。情緒分析需基於 VAD 模型（Valence-Arousal-Dominance），根據對話內容和健康數據動態生成 emotionVector 的值，範圍嚴格限制在 1-100：
+                你的任務: 根據以下的健康報告摘要與對話紀錄，產生一份結構化的分析報告，並將身心狀態串連在一起給出建議。切記不可直接揭露血壓、血脂等具體檢驗數值，需以趨勢或感受性的描述代替。情緒分析需基於 VAD 模型（Valence-Arousal-Dominance），根據對話內容和健康數據動態生成 emotionVector 的值，範圍嚴格限制在 1-100：
                 - Valence（情緒正負）：反映對話中的正面（高分）或負面（低分）情緒。
                 - Arousal（喚醒度）：反映對話中的情緒強度，低分表示平靜，高分表示激動。
                 - Dominance（支配感）：反映對話中用戶的控制感，低分表示無力感，高分表示掌控感。
@@ -1319,7 +1327,7 @@
 
                 請嚴格遵循以下的 JSON 格式回傳，不要有任何額外的文字或解釋:
                 {
-                "summary": "一段約 100-150 字的溫暖總結，用第二人稱（你）的角度，同理並總結使用者的狀況。必須遵循上述的風格指南，使用 **粗體** 和表情符號 ✨。",
+                "summary": "一段約 100-150 字的溫暖總結，用第二人稱（你）的角度，同理並總結使用者的狀況。不可出現任何檢驗數值或具體數字，需用趨勢性的描述呈現健康面向。必須遵循上述的風格指南，使用 **粗體** 和表情符號 ✨。",
                 "keywords": ["一個包含3-5個核心議題關鍵字的陣列"],
                 "emotionVector": {
                     "valence": "1-100 的整數，基於對話情緒正負",


### PR DESCRIPTION
🟡 1007
app.py

- 修改『圖卡生成推薦』：擴充 Gemini prompt，要求回傳含 movie/music/activity 的推薦，同時加入 _fallback_recommendations / _normalize_recommendations 並在 build_cat_card 中整合；推薦隨機取兩則傳給前端，保留分數資料以備後用。

templates/generate_card.html

- 修改圖卡：新增推薦清單樣式，移除舊的指數區塊，生成一至兩則影音/活動建議。
- 將推薦卡改為左右排版、統一底色與框線，貓咪對話泡泡限制 12 字。
- 統一圖卡漸層來源、擴大卡片尺寸 (最終寬度 ~562px、9:14.4 比例)
- 放大字體、擴大圖片 125%，泡泡顯示完整心情小語並移除寒暄，推薦區只用單一底色/框線區隔

🟡 Prompt 更新：要求 LLM 回覆摘要時不露出精確檢驗數值、以趨勢語句呈現。